### PR TITLE
Adding support for bill payment services including: mtn, zain, sudani…

### DIFF
--- a/lib/src/main/java/com/solus/sdk/Library.java
+++ b/lib/src/main/java/com/solus/sdk/Library.java
@@ -7,8 +7,25 @@ import com.solus.sdk.model.BaseResponse;
 import com.solus.sdk.model.ErrorResponse;
 import com.solus.sdk.model.Payment;
 import com.solus.sdk.model.Response;
+import com.solus.sdk.model.types;
 import com.solus.sdk.noebscall.NOEBSClient;
 
+
+/*
+* How to use noebs SDK
+* - special payment:
+* use types.SpecialPayment
+* - Zain:
+* use types.ZainTopUp
+* - MTN:
+* use types.MTNTopUp
+* - Sudani:
+* use types.SudaniTopUp
+* - NEC:
+* use types.NEC
+* - E15:
+* use types.E15
+* */
 public class Library {
     public static void main(String[] args) {
 		Payment payment = new Payment("gdljdfslkgjf;lgks", "123456789101112131", "2206", "1234", 10f);

--- a/lib/src/main/java/com/solus/sdk/model/Payment.java
+++ b/lib/src/main/java/com/solus/sdk/model/Payment.java
@@ -8,6 +8,35 @@ public class Payment {
     private String expDate;
     private String ipin;
     private Float tranAmount;
+    private String payeeId;
+
+	public String getPayeeId() {
+		return payeeId;
+	}
+
+	public void setPayeeId(String payeeId) {
+		this.payeeId = payeeId;
+	}
+
+	public String getPaymentInfo() {
+		return paymentInfo;
+	}
+
+	public void setPaymentInfo(String paymentInfo) {
+		this.paymentInfo = paymentInfo;
+	}
+
+	private String paymentInfo;
+
+	public types getBillerId() {
+		return billerId;
+	}
+
+	public void setBillerId(types billerId) {
+		this.billerId = billerId;
+	}
+
+	private types billerId;
 
 	
 	public Payment() {
@@ -15,11 +44,52 @@ public class Payment {
 	}
 
 	public Payment(String apiKey, String pan, String expDate, String ipin, Float tranAmount) {
-				this.apiKey = apiKey;
+		this.apiKey = apiKey;
 		this.pan = pan;
 		this.expDate = expDate;
 		this.ipin = ipin;
 		this.tranAmount = tranAmount;
+	}
+
+	public Payment(String apiKey, String pan, String expDate, String ipin, Float tranAmount, types billerId, String paymentInfo) {
+		this.apiKey = apiKey;
+		this.pan = pan;
+		this.expDate = expDate;
+		this.ipin = ipin;
+		this.tranAmount = tranAmount;
+		/*
+		this.billerId = billerId;
+		this.paymentInfo = paymentInfo;
+		*
+		const (
+			zain   = "0010010001"
+			mtn    = "0010010003"
+			sudani = "0010010005"
+			nec    = "0010020001"
+		)
+		 */
+		if (billerId == types.E15) {
+			this.payeeId = Constants.e15;
+			this.paymentInfo = paymentInfo;
+
+		}else if (billerId == types.MTNTopUp) {
+			this.payeeId = Constants.mtn;
+			this.paymentInfo = "MPHONE=" + paymentInfo;
+
+		}else if (billerId == types.SudaniTopUp) {
+			this.payeeId = Constants.sudani;
+			this.paymentInfo = "MPHONE=" + paymentInfo;
+
+		} else if (billerId == types.ZainTopUp) {
+				this.payeeId = Constants.zain;
+				this.paymentInfo = "MPHONE=" + paymentInfo;
+
+		}else if (billerId == types.NEC) {
+			this.payeeId = Constants.nec;
+			this.paymentInfo = "METER=" + paymentInfo;
+		}
+
+
 	}
 
 	public Float getTranAmount() {
@@ -54,4 +124,12 @@ public class Payment {
 		this.ipin = ipin;
 	}
 
+}
+
+class Constants {
+	public static String zain = "0010010001";
+	public static String mtn = "0010010003";
+	public static String sudani = "0010010005";
+	public static String e15 = "0010050001";
+	public static String nec = "0010020001";
 }

--- a/lib/src/main/java/com/solus/sdk/model/Request.java
+++ b/lib/src/main/java/com/solus/sdk/model/Request.java
@@ -16,8 +16,37 @@ public class Request implements Serializable {
     private String expDate;
     private String IPIN;
     private Float tranAmount;
+	private String paymentInfo;
+	private String payeeId;
+
+	public String getPaymentInfo() {
+		return paymentInfo;
+	}
+
+	public void setPaymentInfo(String paymentInfo) {
+		this.paymentInfo = paymentInfo;
+	}
+
+	public String getPayeeId() {
+		return payeeId;
+	}
+
+	public void setPayeeId(String payeeId) {
+		this.payeeId = payeeId;
+	}
+
+	public String getServiceProviderId() {
+		return serviceProviderId;
+	}
+
+	public void setServiceProviderId(String serviceProviderId) {
+		this.serviceProviderId = serviceProviderId;
+	}
+
+	private String serviceProviderId;
     private String tranCurrencyCode = "SDG";
 	private String UUID;
+
 
 	public String getUUID() {
 		return UUID;
@@ -26,7 +55,6 @@ public class Request implements Serializable {
 	public void setUUID(String UUID) {
 		this.UUID = UUID;
 	}
-
 
 
     public String getDate(){
@@ -65,7 +93,6 @@ public class Request implements Serializable {
 	public void setTranAmount(Float tranAmount) {
 		this.tranAmount = tranAmount;
 	}
-
 	public String getTranCurrencyCode() {
 		return tranCurrencyCode;
 	}

--- a/lib/src/main/java/com/solus/sdk/model/types.java
+++ b/lib/src/main/java/com/solus/sdk/model/types.java
@@ -1,0 +1,9 @@
+package com.solus.sdk.model;
+
+public enum types {
+    ZainTopUp,
+    MTNTopUp,
+    SudaniTopUp,
+    E15,
+    NEC
+}


### PR DESCRIPTION
We simply use methods overloading to differentiate between special payment APIs and those of bill payment apis.

In order to use the bill payment api, we added types.TypeName for E15, telecos and other services. With the specific type we can set the request fields including (payeeId and paymentInfo) correctly.